### PR TITLE
SP-12502 - fixed metadata initialization

### DIFF
--- a/client/src/main/generated/com/regula/facesdk/webclient/gen/model/GroupToCreate.java
+++ b/client/src/main/generated/com/regula/facesdk/webclient/gen/model/GroupToCreate.java
@@ -43,7 +43,7 @@ public class GroupToCreate {
 
   public static final String SERIALIZED_NAME_METADATA = "metadata";
   @SerializedName(SERIALIZED_NAME_METADATA)
-  private Map<String, Object> metadata = null;
+  private Map<String, Object> metadata = new HashMap<>();
 
   public GroupToCreate() { 
   }


### PR DESCRIPTION
# Description

Changed metadata initialization in GroupToCreate.java from null to "new HashMap<>()"

# Ticket link

https://app.clickup.com/t/4535044/SP-12502

# Change type

Bug fix