### PR TITLE
SP-12384 - fixed groupId's type for updateGroup

### DIFF
--- a/client/src/main/java/com/regula/facesdk/webclient/api/GroupApi.java
+++ b/client/src/main/java/com/regula/facesdk/webclient/api/GroupApi.java
@@ -52,8 +52,8 @@ public class GroupApi extends com.regula.facesdk.webclient.gen.api.GroupApi {
     public void updateGroup(UUID groupId, GroupToCreate groupToCreate, String xRequestID) throws ApiException {
         super.updateGroup(groupId, groupToCreate, xRequestID);
     }
-    public void updateGroup(Integer groupId, GroupToCreate groupToCreate) throws ApiException {
-        this.updateGroup(groupId, groupToCreate);
+    public void updateGroup(UUID groupId, GroupToCreate groupToCreate) throws ApiException {
+        super.updateGroup(groupId, groupToCreate, "");
     }
 
     public void updatePersonsInGroup(UUID groupId, UpdateGroup updateGroup, String xRequestID) throws ApiException {


### PR DESCRIPTION
# Description

Changed updateGroup's groupId type from Integer to UUID in GroupApi.java

# Ticket link

https://app.clickup.com/t/862kjmx72

# Change type

 Bug fix

# Notes

<!-- Please include any other relavant information here -->