### PR TITLE
Metadata creation fix

### DIFF
--- a/client/src/main/java/com/regula/facesdk/webclient/api/GroupApi.java
+++ b/client/src/main/java/com/regula/facesdk/webclient/api/GroupApi.java
@@ -4,6 +4,7 @@ import com.regula.facesdk.webclient.ApiClient;
 import com.regula.facesdk.webclient.ApiException;
 import com.regula.facesdk.webclient.gen.model.*;
 
+import java.util.HashMap;
 import java.util.UUID;
 
 public class GroupApi extends com.regula.facesdk.webclient.gen.api.GroupApi {
@@ -15,9 +16,11 @@ public class GroupApi extends com.regula.facesdk.webclient.gen.api.GroupApi {
     }
 
     public Group createGroup(GroupToCreate groupToCreate, String xRequestID) throws ApiException {
+        if (groupToCreate.getMetadata() == null) groupToCreate.setMetadata(new HashMap<String, Object>());
         return super.createGroup(groupToCreate, xRequestID);
     }
     public Group createGroup(GroupToCreate groupToCreate) throws ApiException {
+        if (groupToCreate.getMetadata() == null) groupToCreate.setMetadata(new HashMap<String, Object>());
         return this.createGroup(groupToCreate, "");
     }
 
@@ -50,10 +53,12 @@ public class GroupApi extends com.regula.facesdk.webclient.gen.api.GroupApi {
     }
 
     public void updateGroup(UUID groupId, GroupToCreate groupToCreate, String xRequestID) throws ApiException {
+        if (groupToCreate.getMetadata() == null) groupToCreate.setMetadata(new HashMap<String, Object>());
         super.updateGroup(groupId, groupToCreate, xRequestID);
     }
-    public void updateGroup(Integer groupId, GroupToCreate groupToCreate) throws ApiException {
-        this.updateGroup(groupId, groupToCreate);
+    public void updateGroup(UUID groupId, GroupToCreate groupToCreate) throws ApiException {
+        if (groupToCreate.getMetadata() == null) groupToCreate.setMetadata(new HashMap<String, Object>());
+        this.updateGroup(groupId, groupToCreate, "");
     }
 
     public void updatePersonsInGroup(UUID groupId, UpdateGroup updateGroup, String xRequestID) throws ApiException {

--- a/client/src/main/java/com/regula/facesdk/webclient/api/PersonApi.java
+++ b/client/src/main/java/com/regula/facesdk/webclient/api/PersonApi.java
@@ -5,6 +5,7 @@ import com.regula.facesdk.webclient.ApiException;
 import com.regula.facesdk.webclient.gen.model.*;
 
 import java.io.File;
+import java.util.HashMap;
 import java.util.UUID;
 
 public class PersonApi extends com.regula.facesdk.webclient.gen.api.PersonApi {
@@ -16,10 +17,12 @@ public class PersonApi extends com.regula.facesdk.webclient.gen.api.PersonApi {
     }
 
     public Person createPerson(PersonFields personFields, String xRequestID) throws ApiException {
+        if (personFields.getMetadata() == null) personFields.setMetadata(new HashMap<String, Object>());
         return super.createPerson(personFields, xRequestID);
     }
 
     public Person createPerson(PersonFields personFields) throws ApiException {
+        if (personFields.getMetadata() == null) personFields.setMetadata(new HashMap<String, Object>());
         return this.createPerson(personFields, "");
     }
 
@@ -74,9 +77,11 @@ public class PersonApi extends com.regula.facesdk.webclient.gen.api.PersonApi {
     }
 
     public void updatePerson(UUID personId, PersonFields personFields, String xRequestID) throws ApiException {
+        if (personFields.getMetadata() == null) personFields.setMetadata(new HashMap<String, Object>());
         super.updatePerson(personId, personFields, xRequestID);
     }
     public void updatePerson(UUID personId, PersonFields personFields) throws ApiException {
+        if (personFields.getMetadata() == null) personFields.setMetadata(new HashMap<String, Object>());
         super.updatePerson(personId, personFields, "");
     }
 }


### PR DESCRIPTION
# Description
This commit fixes metadata creation for groupToCreate and personFields. Even if metadata isn't in request it should be sent at least as new HashMap<String, Object>() to avoid 400 BAD REQUEST code.
Additionally fixed groupId type from integer to UUID in updateGroup
<!-- Please include a summary of the changes. -->

# Ticket link
https://app.clickup.com/t/862kjmxg9
https://app.clickup.com/t/862kk9w1h
<!-- Please include all the tickets links related with this change -->

# Change type

<!-- Please select the change type -->

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (fix or feature that would cause existing functionality to not work as expected) -->
- [ ] Add/Update documentation

# Notes

<!-- Please include any other relavant information here -->